### PR TITLE
Mark the mojo as thread safe for parallel builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.github.wvengen</groupId>
     <artifactId>proguard-maven-plugin</artifactId>
     <name>proguard-maven-plugin</name>
-    <version>2.0.5</version>
+    <version>2.0.6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <description>Maven 2 Plugin for ProGuard</description>
@@ -68,6 +68,16 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>2.9</version>
+                </plugin>
+        </plugins>
+    </build>
 
 </project>
 

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -53,6 +53,7 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
  * @phase package
  * @description Create small jar files using ProGuard
  * @requiresDependencyResolution compile
+ * @threadSafe
  */
 
 public class ProGuardMojo extends AbstractMojo {
@@ -227,7 +228,7 @@ public class ProGuardMojo extends AbstractMojo {
 	/**
 	 * The Jar archiver.
 	 * 
-	 * @parameter expression="${component.org.codehaus.plexus.archiver.Archiver#jar}"
+	 * @component role="org.codehaus.plexus.archiver.Archiver" roleHint="jar"
 	 * @required
 	 */
 	private JarArchiver jarArchiver;


### PR DESCRIPTION
It seems safe to mark this plugin as thread safe for parallel builds
(https://cwiki.apache.org/MAVEN/parallel-builds-in-maven-3.html). Using
the threadSafe annotation requires upgrading maven-plugin-plugin. The
other change in this commit (converting @parameter to @component) is
just to get rid of a warning message that the upgraded
maven-plugin-plugin displays during the build of proguard-maven-plugin
itself.
