### PR TITLE
Allow plugin execution on pom projects, upgrade to Proguard 4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>net.sf.proguard</groupId>
             <artifactId>proguard-base</artifactId>
-            <version>4.8</version>
+            <version>4.9</version>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
I required the plugin to operate on projects with pom packaging that manually defined injars for processing (e.g. shaded or copied jars).

The changes made allow this, as well as upgrade to the latest version of proguard fo up-to-date-ness sake.

It would be greatly appreciated if you could deploy a new patch release to maven central after applying the proposed changes to make the artifacts more easily accessible for everyone.
