### PR TITLE
Support Java 8 by upgrading to ProGuard 5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>com.github.wvengen</groupId>
 	<artifactId>proguard-maven-plugin</artifactId>
 	<name>proguard-maven-plugin</name>
-	<version>5.0</version>
+	<version>2.0.8-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<description>Maven 2 Plugin for ProGuard</description>


### PR DESCRIPTION
Proguard 5.0 which supports Java 8 was released.
http://proguard.sourceforge.net/downloads.html
This patch changes ProGuard version from 4.11 to 5.0

Additionally, I think it is better that proguard-maven-plugin and ProGuard version are matched from the view point of perspicuity.
