### PR TITLE
make it possible to use dexguard

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -81,12 +81,12 @@ public class ProGuardMojo extends AbstractMojo {
 	 */
 	private String proguardVersion;
 
-    /**
-     * To run DexGuard instead of ProGuard, set this to "true".
-     *
-     * @parameter default-value="false"
-     */
-    private boolean useDexGuard;
+	/**
+	 * To run DexGuard instead of ProGuard, set this to "true".
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean useDexGuard;
 
 	/**
 	 * ProGuard configuration options
@@ -327,11 +327,11 @@ public class ProGuardMojo extends AbstractMojo {
 	 * ProGuard docs: Names with special characters like spaces and parentheses must be quoted with single or double
 	 * quotes.
 	 */
-	private static String fileNameToString(String fileName) {
+	private String fileNameToString(String fileName) {
 		return "'" + fileName + "'";
 	}
 
-	private static String fileToString(File file) {
+	private String fileToString(File file) {
 		return fileNameToString(file.toString());
 	}
 
@@ -680,7 +680,7 @@ public class ProGuardMojo extends AbstractMojo {
 		}
 	}
 
-	private static File getProguardJar(ProGuardMojo mojo) throws MojoExecutionException {
+	private File getProguardJar(ProGuardMojo mojo) throws MojoExecutionException {
 
 		Artifact proguardArtifact = null;
 		int proguardArtifactDistance = -1;
@@ -729,7 +729,7 @@ public class ProGuardMojo extends AbstractMojo {
 		return new File(proguardJar);
 	}
 
-	private static void proguardMain(File proguardJar, List<String> argsList, ProGuardMojo mojo)
+	private void proguardMain(File proguardJar, List<String> argsList, ProGuardMojo mojo)
 			throws MojoExecutionException {
 
 		Java java = new Java();
@@ -774,7 +774,7 @@ public class ProGuardMojo extends AbstractMojo {
 		}
 	}
 
-	private static String nameNoType(String fileName) {
+	private String nameNoType(String fileName) {
 		int extStart = fileName.lastIndexOf('.');
 		if (extStart == -1) {
 			return fileName;
@@ -782,7 +782,7 @@ public class ProGuardMojo extends AbstractMojo {
 		return fileName.substring(0, extStart);
 	}
 
-	private static boolean deleteFileOrDirectory(File path) throws MojoFailureException {
+	private boolean deleteFileOrDirectory(File path) throws MojoFailureException {
 		if (path.isDirectory()) {
 			File[] files = path.listFiles();
 			if (null != files) {
@@ -805,7 +805,7 @@ public class ProGuardMojo extends AbstractMojo {
 	}
 
 
-	private static Artifact getDependency(Inclusion inc, MavenProject mavenProject) throws MojoExecutionException {
+	private Artifact getDependency(Inclusion inc, MavenProject mavenProject) throws MojoExecutionException {
 		@SuppressWarnings("unchecked")
 		Set<Artifact> dependency = mavenProject.getArtifacts();
 		for (Artifact artifact : dependency) {
@@ -828,7 +828,7 @@ public class ProGuardMojo extends AbstractMojo {
 		return false;
 	}
 
-	private static File getClasspathElement(Artifact artifact, MavenProject mavenProject) throws MojoExecutionException {
+	private File getClasspathElement(Artifact artifact, MavenProject mavenProject) throws MojoExecutionException {
 		if (artifact.getClassifier() != null) {
 			return artifact.getFile();
 		}

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -81,6 +81,13 @@ public class ProGuardMojo extends AbstractMojo {
 	 */
 	private String proguardVersion;
 
+    /**
+     * To run DexGuard instead of ProGuard, set this to "true".
+     *
+     * @parameter default-value="false"
+     */
+    private boolean useDexGuard;
+
 	/**
 	 * ProGuard configuration options
 	 *
@@ -681,7 +688,7 @@ public class ProGuardMojo extends AbstractMojo {
 		for (Artifact artifact : mojo.pluginArtifacts) {
 			mojo.getLog().debug("pluginArtifact: " + artifact.getFile());
 			final String artifactId = artifact.getArtifactId();
-			if (artifactId.startsWith("proguard") &&
+			if (artifactId.startsWith((useDexGuard?"dexguard":"proguard")) &&
 				!artifactId.startsWith("proguard-maven-plugin")) {
 				int distance = artifact.getDependencyTrail().size();
 				mojo.getLog().debug("proguard DependencyTrail: " + distance);
@@ -701,7 +708,7 @@ public class ProGuardMojo extends AbstractMojo {
 			mojo.getLog().debug("proguardArtifact: " + proguardArtifact.getFile());
 			return proguardArtifact.getFile().getAbsoluteFile();
 		}
-		mojo.getLog().info("proguard jar not found in pluginArtifacts");
+		mojo.getLog().info((useDexGuard?"dexguard":"proguard") + " jar not found in pluginArtifacts");
 
 		ClassLoader cl;
 		cl = mojo.getClass().getClassLoader();


### PR DESCRIPTION
This is a rework of the [pull-request 6](https://github.com/wvengen/proguard-maven-plugin/pull/6), but with a different approach. As there is only "dexguard" or "proguard", this might be covered by boolean-switch instead of failure-proven String-switch.