### PR TITLE
Fix #55 attach ProGuard map and seed files as artifacts if injar and outjar filename are the same.

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -668,14 +668,17 @@ public class ProGuardMojo extends AbstractMojo {
 
 		}
 
-		if (attach && !sameArtifact) {
-			final String classifier;
-			if (useArtifactClassifier()) {
-				classifier = attachArtifactClassifier;
-			} else {
-				classifier = null;
+		if (attach) {
+			if (!sameArtifact) {
+				final String classifier;
+				if (useArtifactClassifier()) {
+					classifier = attachArtifactClassifier;
+				} else {
+					classifier = null;
+				}
+
+				projectHelper.attachArtifact(mavenProject, attachArtifactType, classifier, outJarFile);
 			}
-			projectHelper.attachArtifact(mavenProject, attachArtifactType, classifier, outJarFile);
 
 			final String mainClassifier = useArtifactClassifier() ? attachArtifactClassifier : null;
 			final File buildOutput = new File(mavenProject.getBuild().getDirectory());


### PR DESCRIPTION
This fixes issue #55 by separating the attachment of the ProGuard map/seed files as artifacts from the attachment of the ProGuard jar artifact.