### PR TITLE
Assembly inclusions list generic

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/Assembly.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/Assembly.java
@@ -24,6 +24,6 @@ import java.util.List;
 
 public class Assembly {
 
-	protected List inclusions;
+	protected List<Inclusion> inclusions;
 
 }

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -450,9 +450,7 @@ public class ProGuardMojo extends AbstractMojo {
 		Set<String> inPath = new HashSet<String>();
 		boolean hasInclusionLibrary = false;
 		if (assembly != null && assembly.inclusions != null) {
-			@SuppressWarnings("unchecked")
-			final List<Inclusion> inclusions = assembly.inclusions;
-			for (Inclusion inc : inclusions) {
+			for (Inclusion inc : assembly.inclusions) {
 				if (!inc.library) {
 					File file = getClasspathElement(getDependency(inc, mavenProject), mavenProject);
 					inPath.add(file.toString());
@@ -643,9 +641,7 @@ public class ProGuardMojo extends AbstractMojo {
 
 			try {
 				jarArchiver.addArchivedFileSet(baseFile);
-				@SuppressWarnings("unchecked")
-				final List<Inclusion> inclusions = assembly.inclusions;
-				for (Inclusion inc : inclusions) {
+				for (Inclusion inc : assembly.inclusions) {
 					if (inc.library) {
 						File file;
 						Artifact artifact = getDependency(inc, mavenProject);


### PR DESCRIPTION
Copy&Past from #65 

Hi.
I'm working with this plugin, but there is an embarrassing case in auto-completion (in my case, on eclipse).
In Assembly class, there is an inclusions list that is no typed.
This imply auto-completion not working because of raw type.

Anyway, in code, inclusions list is getted as an `List<Inclusion>` line 647-648 : https://github.com/wvengen/proguard-maven-plugin/blob/f0ec275312f039978fa0f46f3d2b497f66ad4101/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java#L646
https://github.com/wvengen/proguard-maven-plugin/blob/f0ec275312f039978fa0f46f3d2b497f66ad4101/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java#L647

Can you just change `List inclusions` to `List<Inclusion> inclusions` in Assembly class ?
https://github.com/wvengen/proguard-maven-plugin/blob/f0ec275312f039978fa0f46f3d2b497f66ad4101/src/main/java/com/github/wvengen/maven/proguard/Assembly.java#L27