### PR TITLE
Feature/full wildcard support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
 		</developer>
 	</developers>
 
+	<contributors>
+		<contributor>
+			<name>Chuckame</name>
+			<email>chuckame@gmail.com</email>
+		</contributor>
+	</contributors>
 
 	<dependencies>
 

--- a/src/main/java/com/github/wvengen/maven/proguard/ArtifactFilter.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ArtifactFilter.java
@@ -37,22 +37,31 @@ public class ArtifactFilter {
     protected String classifier;
 
     public boolean match(Artifact artifact) {
-        boolean artifactMatch = WILDCARD.equals(artifactId) || artifact.getArtifactId().equals(this.artifactId) ||
-                (artifactId != null && getMatcher(artifact).matches());
-        boolean groupMatch = artifact.getGroupId().equals(this.groupId);
+        boolean artifactMatch = WILDCARD.equals(this.artifactId) || artifact.getArtifactId().equals(this.artifactId) ||
+                (artifactId != null && getArtifactIdMatcher(artifact).matches());
+        boolean groupMatch = artifact.getGroupId().equals(this.groupId) ||
+                (groupId != null && getGroupIdMatcher(artifact).matches());
         boolean classifierMatch = ((this.classifier == null) && (artifact.getClassifier() == null)) || ((this.classifier != null) && this.classifier.equals(artifact.getClassifier()));
         return artifactMatch && groupMatch && classifierMatch;
     }
 
-    private Matcher getMatcher(Artifact artifact) {
+    private Matcher getArtifactIdMatcher(Artifact artifact) {
         try {
             Pattern compile = Pattern.compile(escapeRegex(this.artifactId));
             return compile.matcher(artifact.getArtifactId());
         } catch (PatternSyntaxException e) {
-            throw new IllegalArgumentException("Invalid regex artifact filter: " + this, e);
+            throw new IllegalArgumentException("Invalid regex artifactId filter: " + this, e);
         }
     }
 
+    private Matcher getGroupIdMatcher(Artifact artifact) {
+        try {
+            Pattern compile = Pattern.compile(escapeRegex(this.groupId));
+            return compile.matcher(artifact.getGroupId());
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid regex groupId filter: " + this, e);
+        }
+    }
     
     /**
      * Escape regex and keep wildcard.<br>

--- a/src/main/java/com/github/wvengen/maven/proguard/ArtifactFilter.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ArtifactFilter.java
@@ -46,11 +46,22 @@ public class ArtifactFilter {
 
     private Matcher getMatcher(Artifact artifact) {
         try {
-            Pattern compile = Pattern.compile(artifactId);
+            Pattern compile = Pattern.compile(escapeRegex(this.artifactId));
             return compile.matcher(artifact.getArtifactId());
         } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException("Invalid regex artifact filter: " + this, e);
         }
+    }
+
+    
+    /**
+     * Escape regex and keep wildcard.<br>
+     * {@link Pattern#quote(String)} method wrap string between '\Q' for starting ignoring and '\E' for ending ignoring,<br>
+     * so we don't want to escape wildcard.<br>
+     * 'myregexpart1*myregexpart2' becomes '\Qmyregexpart1\E.*\Qmyregexpart2\E'.
+     */
+    private String escapeRegex(String str) {
+    	return Pattern.quote(str).replace(WILDCARD, "\\E.*\\Q");
     }
 
     @Override

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -662,20 +662,16 @@ public class ProGuardMojo extends AbstractMojo {
 
 			try {
 				jarArchiver.addArchivedFileSet(baseFile);
-				@SuppressWarnings("unchecked")
-				final List<Inclusion> inclusions = assembly.inclusions;
-				for (Inclusion inc : inclusions) {
-					if (inc.library) {
-						File file;
-						Artifact artifact = getDependency(inc, mavenProject);
-						file = getClasspathElement(artifact, mavenProject);
-						if (file.isDirectory()) {
-							getLog().info("merge project: " + artifact.getArtifactId() + " " + file);
-							jarArchiver.addDirectory(file);
-						} else {
-							getLog().info("merge artifact: " + artifact.getArtifactId());
-							jarArchiver.addArchivedFileSet(file);
-						}
+
+				for (Entry<Artifact, Inclusion> entry : libraryjars.entrySet()) {
+					File file;
+					file = getClasspathElement(entry.getKey(), mavenProject);
+					if (file.isDirectory()) {
+						getLog().info("merge project: " + entry.getKey() + " " + file);
+						jarArchiver.addDirectory(file);
+					} else {
+						getLog().info("merge artifact: " + entry.getKey());
+						jarArchiver.addArchivedFileSet(file);
 					}
 				}
 

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -857,6 +857,21 @@ public class ProGuardMojo extends AbstractMojo {
 		throw new MojoExecutionException("artifactId Not found " + inc.artifactId);
 	}
 
+	private Set<Artifact> getDependencies(final Inclusion inc, MavenProject mavenProject) throws MojoExecutionException {
+		@SuppressWarnings("unchecked")
+		Set<Artifact> dependencies = mavenProject.getArtifacts();
+		Set<Artifact> result = new HashSet<Artifact>();
+		for (Artifact artifact : dependencies) {
+			if (inc.match(artifact)) {
+				result.add(artifact);
+			}
+		}
+		if (result.isEmpty()) {
+			log.warn(String.format("No artifact found : %s:%s", inc.artifactId, inc.groupId));
+		}
+		return result;
+	}
+
 	private boolean isExclusion(Artifact artifact) {
 		if (exclusions == null) {
 			return false;

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -860,18 +860,6 @@ public class ProGuardMojo extends AbstractMojo {
 		}
 	}
 
-
-	private Artifact getDependency(Inclusion inc, MavenProject mavenProject) throws MojoExecutionException {
-		@SuppressWarnings("unchecked")
-		Set<Artifact> dependency = mavenProject.getArtifacts();
-		for (Artifact artifact : dependency) {
-			if (inc.match(artifact)) {
-				return artifact;
-			}
-		}
-		throw new MojoExecutionException("artifactId Not found " + inc.artifactId);
-	}
-
 	private Set<Artifact> getDependencies(final Inclusion inc, MavenProject mavenProject) throws MojoExecutionException {
 		@SuppressWarnings("unchecked")
 		Set<Artifact> dependencies = mavenProject.getArtifacts();

--- a/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
+++ b/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
@@ -1,6 +1,7 @@
 package com.github.wvengen.maven.proguard;
 
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -26,10 +27,26 @@ public class ArtifactFilterTest {
     }
 
     @Test
-    public void wildcardMatch() {
+    public void wildcardMatch_allArtifact() {
         artifactFilter.groupId = "com.mahifx";
         artifactFilter.artifactId = "*";
         Assert.assertTrue(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void wildcardMatch_partOfArtifact() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "lib*";
+        Assert.assertTrue(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void wildcardMatch_escapeArtifactDots() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "li.*";
+        Artifact artifact = getArtifact();
+        artifact.setArtifactId("li.b");
+        Assert.assertTrue(artifactFilter.match(artifact));
     }
 
     @Test
@@ -38,28 +55,6 @@ public class ArtifactFilterTest {
         artifactFilter.artifactId = "libB-utils";
         Assert.assertFalse(artifactFilter.match(getArtifact()));
     }
-
-    @Test
-    public void regexMatch() {
-        artifactFilter.groupId = "com.mahifx";
-        artifactFilter.artifactId = "lib.*";
-        Assert.assertTrue(artifactFilter.match(getArtifact()));
-    }
-
-    @Test
-    public void regexNoMatch() {
-        artifactFilter.groupId = "com.mahifx";
-        artifactFilter.artifactId = "foo.+";
-        Assert.assertFalse(artifactFilter.match(getArtifact()));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void invalidRegex() {
-        artifactFilter.groupId = "com.mahifx";
-        artifactFilter.artifactId = "+";
-        artifactFilter.match(getArtifact());
-    }
-
 
     private DefaultArtifact getArtifact() {
         return new DefaultArtifact("com.mahifx", "libA", VersionRange.createFromVersion("1.0.0"), "compile", "jar", null, new DefaultArtifactHandler());

--- a/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
+++ b/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
@@ -50,13 +50,46 @@ public class ArtifactFilterTest {
     }
 
     @Test
+    public void wildcardNoMatch_escapeArtifactDots() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "li.b";
+        Assert.assertFalse(artifactFilter.match(getArtifact("com.mahifx", "liTb")));
+    }
+
+    @Test
     public void noMatchWithRegexTokens() {
         artifactFilter.groupId = "com.mahifx";
         artifactFilter.artifactId = "libB-utils";
         Assert.assertFalse(artifactFilter.match(getArtifact()));
     }
 
+    @Test
+    public void wildcardMatch_partOfGroupId() {
+        artifactFilter.groupId = "com.ma*";
+        artifactFilter.artifactId = "libA";
+        Assert.assertTrue(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void simpleMatch() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "libA";
+        Assert.assertTrue(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void wildcardMatch_subGroup() {
+        artifactFilter.groupId = "com.mahifx.*";
+        artifactFilter.artifactId = "libA";
+        Assert.assertTrue(artifactFilter.match(getArtifact("com.mahifx.subgroup", "libA")));
+        Assert.assertTrue(artifactFilter.match(getArtifact("com.mahifx.subgroup.subsubgroup", "libA")));
+    }
+
     private DefaultArtifact getArtifact() {
-        return new DefaultArtifact("com.mahifx", "libA", VersionRange.createFromVersion("1.0.0"), "compile", "jar", null, new DefaultArtifactHandler());
+        return getArtifact("com.mahifx", "libA");
+    }
+    
+    private DefaultArtifact getArtifact(String groupId, String artifactId) {
+        return new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion("1.0.0"), "compile", "jar", null, new DefaultArtifactHandler());
     }
 }

--- a/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
+++ b/src/test/java/com/github/wvengen/maven/proguard/ArtifactFilterTest.java
@@ -12,17 +12,24 @@ public class ArtifactFilterTest {
     private ArtifactFilter artifactFilter = new ArtifactFilter();
 
     @Test
-    public void wildcardMatch() {
-        artifactFilter.groupId = "com.mahifx";
-        artifactFilter.artifactId = "*";
-        Assert.assertTrue(artifactFilter.match(getArtifact()));
-    }
-
-    @Test
     public void noMatch() {
         artifactFilter.groupId = "com.mahifx";
         artifactFilter.artifactId = "libB";
         Assert.assertFalse(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void emptyArtifactDoesNotMatch() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "";
+        Assert.assertFalse(artifactFilter.match(getArtifact()));
+    }
+
+    @Test
+    public void wildcardMatch() {
+        artifactFilter.groupId = "com.mahifx";
+        artifactFilter.artifactId = "*";
+        Assert.assertTrue(artifactFilter.match(getArtifact()));
     }
 
     @Test
@@ -43,13 +50,6 @@ public class ArtifactFilterTest {
     public void regexNoMatch() {
         artifactFilter.groupId = "com.mahifx";
         artifactFilter.artifactId = "foo.+";
-        Assert.assertFalse(artifactFilter.match(getArtifact()));
-    }
-
-    @Test
-    public void emptyArtifactDoesNotMatch() {
-        artifactFilter.groupId = "com.mahifx";
-        artifactFilter.artifactId = "";
         Assert.assertFalse(artifactFilter.match(getArtifact()));
     }
 


### PR DESCRIPTION
Hi.

Actually, wildcards are not fully supported.

My proposition:
- Add groupId wildcard support.
- Remove regex on artifactId, use only wildcards (the same in regex: `.*`).
- Change wildcard operation to use `*` every where in groupId or artifactId like : 
  * `my.group*` (takes `my.group`, `my.group-extension`, `my.group.subgroup`, ...)
  * `my*artifact` (takes `myartifact`, `mysuperlongartifact`, ...)
  * `myproject-*` (takes `myproject-libs`, `myproject-components`, ...)
  * `*` (takes all)

Fix bug:
- Take all found artifacts from inclusion filter and not only the first. (Issue #67)
