### PR TITLE
Incremental obfuscation functionality

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -21,6 +21,8 @@
 package com.github.wvengen.maven.proguard;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -44,6 +46,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Java;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.IOUtil;
 
 /**
  *
@@ -329,6 +332,15 @@ public class ProGuardMojo extends AbstractMojo {
 	protected File applyMappingFile;
 
 	/**
+	 * Specifies whether or not to enable <a href=
+	 * "https://www.guardsquare.com/en/proguard/manual/examples#incremental">
+	 * incremental obfuscation</a>
+	 *
+	 * @parameter default-value="false"
+	 */
+	private boolean incremental;
+
+	/**
 	 * The proguard jar to use. useful for using beta versions of
 	 * progaurd that aren't yet on Maven central.
 	 *
@@ -606,13 +618,18 @@ public class ProGuardMojo extends AbstractMojo {
 			args.add(fileToString(tempLibraryjarsDir));
 		}
 
+		File mappingFile = new File(outputDirectory, mappingFileName);
 		args.add("-printmapping");
-		args.add(fileToString((new File(outputDirectory, mappingFileName).getAbsoluteFile())));
+		args.add(fileToString(mappingFile.getAbsoluteFile()));
 
 		args.add("-printseeds");
 		args.add(fileToString((new File(outputDirectory,seedFileName).getAbsoluteFile())));
 
-		if (applyMappingFile != null) {
+		if (incremental && applyMappingFile == null) {
+			throw new MojoFailureException("applyMappingFile is required if incremental is true");
+		}
+
+		if (applyMappingFile != null && (!incremental || applyMappingFile.exists())) {
 			args.add("-applymapping");
 			args.add(fileToString(applyMappingFile.getAbsoluteFile()));
 		}
@@ -678,6 +695,27 @@ public class ProGuardMojo extends AbstractMojo {
 				throw new MojoExecutionException("Unable to create jar", e);
 			}
 
+		}
+
+		if (incremental) {
+			log.info("Merging mapping file into " + applyMappingFile);
+
+			try {
+				FileInputStream mappingFileIn = new FileInputStream(mappingFile);
+				try {
+					applyMappingFile.getParentFile().mkdirs();
+					FileOutputStream mappingFileOut = new FileOutputStream(applyMappingFile, true);
+					try {
+						IOUtil.copy(mappingFileIn, mappingFileOut);
+					} finally {
+						mappingFileOut.close();
+					}
+				} finally {
+					mappingFileIn.close();
+				}
+			} catch (IOException e) {
+				throw new MojoExecutionException("Unable to merge mapping file", e);
+			}
 		}
 
 		if (attach) {

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -322,6 +322,13 @@ public class ProGuardMojo extends AbstractMojo {
 	protected String seedFileName = "proguard_seeds.txt";
 
 	/**
+	 * Sets the name of the ProGuard applying mapping file.
+	 *
+	 * @parameter
+	 */
+	protected File applyMappingFile;
+
+	/**
 	 * The proguard jar to use. useful for using beta versions of
 	 * progaurd that aren't yet on Maven central.
 	 *
@@ -604,6 +611,11 @@ public class ProGuardMojo extends AbstractMojo {
 
 		args.add("-printseeds");
 		args.add(fileToString((new File(outputDirectory,seedFileName).getAbsoluteFile())));
+
+		if (applyMappingFile != null) {
+			args.add("-applymapping");
+			args.add(fileToString(applyMappingFile.getAbsoluteFile()));
+		}
 
 		if (log.isDebugEnabled()) {
 			args.add("-verbose");


### PR DESCRIPTION
Since ProGuard supports [incremental obfuscation](https://www.guardsquare.com/proguard/manual/examples#incremental) by specifying `-applymapping`, I propose adding a functionality to incrementally obfuscate projects with multiple modules.

- `root:pom`
  - `test1:jar`
    - `test.Class1`
      - `void method(test.Class1)`
    - `test.Keep1`
  - `test2:jar`
    - `test.Class2`
      - `void method(test.Class1)`
    - `test.Keep2`

(An example of projects that actually work: [incremental-obfuscation.zip](https://github.com/wvengen/proguard-maven-plugin/files/2025747/incremental-obfuscation.zip))

In the project of the above layout, If you specify `proguard_map.txt` which is the result of obfuscating `test1:jar` with `-applymapping` when obfuscating `test2:jar`, ProGuard will consider the result of changing the identifier in `test1:jar`, so `test.Class1` and `test.Class2` will not change to the same name.

In order to support such incremental obfuscation, I introduce the following two parameters.

- `File applyMappingFile (default: none)`
  - If specified, specify that file as `-applymapping` parameter
- `boolean incremental (default: false)`
  - Specify whether to perform incremental obfuscation
  - In the case of `true`, the following behavior changes
    1. Even if `applyMappingFile` is specified, if the file does not exist, omit `-applymapping` (i.e. there is no mapping file to be applied to the originating project)
    2. If the file exists, merge the mapping file of the execution result of ProGuard into the file specified by `applyMappingFile`

In other words, if you set `incremental = true`, you will be able to obfuscate individual modules one by one in projects with multiple modules.

Note that this functionality does not work properly in versions prior to ProGuard 5.3.

>#### Version 5.3 (Sep. 2016)
>- Avoiding obfuscated name clashes with library classes.
