### PR TITLE
switch to proguard 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>net.sf.proguard</groupId>
 			<artifactId>proguard-base</artifactId>
-			<version>5.2.1</version>
+			<version>6.0.3</version>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
Simply use a newer proguard version. 
See https://github.com/wvengen/proguard-maven-plugin/issues/64