### PR TITLE
Bump used Java version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 					<compilerArgs>
 						<arg>-Xlint</arg>
 					</compilerArgs>

--- a/src/it/simple/pom.xml
+++ b/src/it/simple/pom.xml
@@ -12,6 +12,18 @@
     <defaultGoal>install</defaultGoal>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <compilerArgs>
+            <arg>-Xlint</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.github.wvengen</groupId>
         <artifactId>proguard-maven-plugin</artifactId>
         <version>@project.version@</version>


### PR DESCRIPTION
Updates Java source and target to 1.6. Before this change the code didn't actually compile with the latest Maven versions (at least 3.5.0+).