### PR TITLE
Issue-92: If found library is a directory, copy it as such

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>


### PR DESCRIPTION
If found library is a directory, copy it as such, not as a file as previously has been done.

Also adds some debug log statements.
Also now throws MojoFailureException if deleting the temporary directory fails.

Fixes https://github.com/wvengen/proguard-maven-plugin/issues/92