### PR TITLE
Issue-64: Update default Proguard version to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>net.sf.proguard</groupId>
 			<artifactId>proguard-base</artifactId>
-			<version>6.0.3</version>
+			<version>6.1.1</version>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
6.1.1 is currently the latest released version and supports Java versions up to 12.

Fixes #64 