### PR TITLE
Respect filter on library merge

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -750,6 +750,7 @@ public class ProGuardMojo extends AbstractMojo {
 							}
 						    }
 
+						    // Null is important on empty includes otherwise nothing gets included
 						    jarArchiver.addArchivedFileSet(file,
 							    (includes.isEmpty() ? null : includes.toArray(new String[0])),
 							    (excludes.isEmpty() ? null : excludes.toArray(new String[0])));

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -730,7 +730,30 @@ public class ProGuardMojo extends AbstractMojo {
 						jarArchiver.addDirectory(file);
 					} else {
 						getLog().info("merge artifact: " + entry.getKey());
-						jarArchiver.addArchivedFileSet(file);
+						
+						// Respect filter if set
+						String filter = entry.getValue().filter;
+						if(filter == null) {
+							jarArchiver.addArchivedFileSet(file);
+						} else {
+						    
+						    // Filter elements must be separated int two lists
+						    List<String> includes = new ArrayList<String>();
+						    List<String> excludes = new ArrayList<String>();
+
+						    // Elements starting with ! should be excluded while others should be included
+						    for(String element : filter.split(",")) {
+							if(element.startsWith("!")) {
+							    excludes.add(element.substring(1));
+							}else {
+							    includes.add(element);
+							}
+						    }
+
+						    jarArchiver.addArchivedFileSet(file,
+							    (includes.isEmpty() ? null : includes.toArray(new String[0])),
+							    (excludes.isEmpty() ? null : excludes.toArray(new String[0])));
+						}
 					}
 				}
 


### PR DESCRIPTION
I need to add jackson to my project but I there are some files I don't want to be included in the final jar. This pull request addresses the fact that filter is beeing ignored on libraries.

I tested the code and verified that the filter is now working.

Example pom:
```
<inclusion>
  <groupId>com.fasterxml.jackson.core</groupId>
  <artifactId>jackson-databind</artifactId>
  <!-- Some files should not be included in jar -->
  <filter>!META-INF/maven/**,!META-INF/LICENSE,!META-INF/MANIFEST.MF,!META-INF/NOTICE</filter>
  <library>true</library>
</inclusion>
```