### PR TITLE
Fixed ProGuard 7 not finding classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,8 @@
 		<label>NO_LABEL</label>
 		<cctimestamp>NO_TIMESTAMP</cctimestamp>
 		<scm.revision>NO_SCM_REVISION</scm.revision>
+
+		<version.proguard>7.0.0</version.proguard>
 	</properties>
 
 
@@ -86,10 +88,18 @@
 	
 	<dependencies>
 
+		<!-- From version 7 on we need to add two dependencies -->
 		<dependency>
 			<groupId>com.guardsquare</groupId>
 			<artifactId>proguard-base</artifactId>
-			<version>7.0.0</version>
+			<version>${version.proguard}</version>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.guardsquare</groupId>
+			<artifactId>proguard-core</artifactId>
+			<version>${version.proguard}</version>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
Maybe this fixes https://github.com/wvengen/proguard-maven-plugin/issues/112

I added a warning if a dependency is defined twice. This can happen if you do not define proguardVersion but you add a dependency for a different proguard version. The default version of proguard is defined in pom.xml and I did'nt want to define it in java too. If it is possible to get the version out of the pom and into the mojo, I'm happy to add this.

I did different tests with defined and not defined proguardVersion and dependency and no dependency. Everything is working fine now.