### PR TITLE
added generateTemporaryConfigurationFile option

### DIFF
--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -134,7 +134,10 @@ public class ProGuardMojo extends AbstractMojo {
 	private boolean putLibraryJarsInTempDir;
 
 	/**
-	 * Create a temporary configuration file
+	 * Use this parameter if your command line arguments become too long and execution fails.
+     *
+     * If this parameter is 'true', the configuration is passed to the proguard process through a file, instead of through
+     * command line arguments. This bypasses the operating system restrictions on the length of the command line arguments.
 	 *
 	 * @parameter default-value="false"
 	 */

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -715,19 +715,24 @@ public class ProGuardMojo extends AbstractMojo {
 			for (String arg : args) {
 				if (arg.startsWith("-")) {
 					stringBuilder.append("\n");
-				}else{
+				} else {
 					stringBuilder.append(" ");
 				}
 				stringBuilder.append(arg);
 			}
 
+			FileWriter writer = null;
 			try {
-				FileWriter writer = new FileWriter(temporaryConfigurationFile);
+				writer = new FileWriter(temporaryConfigurationFile);
 				IOUtils.write(stringBuilder.toString(), writer);
-				writer.close();
 			} catch (IOException e) {
 				throw new MojoFailureException("cannot write to temporary configuration file " + temporaryConfigurationFile, e);
-			}
+			} finally {
+			    if(writer != null) {
+                    writer.close();
+                }
+            }
+
 			args = new ArrayList<String>();
 			args.add("-include");
 			args.add(fileToString(temporaryConfigurationFile));

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -124,7 +124,7 @@ proguard-maven-plugin
 
         If you have a huge list of dependencies the list of <<<-libraryjars>>> the resulting command line to execute ProGaurd could become too long. On Windows the error message could look like <<<CreateProcess error=206, The filename or extension is too long>>>.
 
-        * <<< <putLibraryJarsInTempDir>true</putLibraryJarsInTempDir> >>> makes the plugin copy all the library jars to a single temporary directory and pass that directory as the only <<<-libraryjars>>> argument to ProGuard. Build performance will be a bit worse, but the command line will be much shorter.
+        * <<< <generateTemporaryConfigurationFile>true</generateTemporaryConfigurationFile> >>> makes the plugin pass the configuration by a temporary file instead of over the command line. Build performance should not be impacted by this.
 
 
 * Usage


### PR DESCRIPTION
``putLibraryJarsInTempDir`` did not work for me. My project had to many -injars, not libraries.

This pull request introduces a new option ``generateTemporaryConfigurationFile`` that generates a temporary proguard configuration file that includes all arguments.

The pull request does not modify other options.

fixes #113 