### PR TITLE
Issue #127: Bump minimum Java version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<compilerArgs>
 						<arg>-Xlint</arg>
 					</compilerArgs>

--- a/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
+++ b/src/main/java/com/github/wvengen/maven/proguard/ProGuardMojo.java
@@ -724,17 +724,11 @@ public class ProGuardMojo extends AbstractMojo {
 				stringBuilder.append(arg);
 			}
 
-			FileWriter writer = null;
-			try {
-				writer = new FileWriter(temporaryConfigurationFile);
+			try (FileWriter writer = new FileWriter(temporaryConfigurationFile);) {
 				IOUtils.write(stringBuilder.toString(), writer);
 			} catch (IOException e) {
 				throw new MojoFailureException("cannot write to temporary configuration file " + temporaryConfigurationFile, e);
-			} finally {
-			    if(writer != null) {
-                    writer.close();
-                }
-            }
+			}
 
 			args = new ArrayList<String>();
 			args.add("-include");


### PR DESCRIPTION
#127 
Bump minimum Java version to 1.8.
Fix broken close call by using try-with-resources.