### PR TITLE
Remove phased-out bintray repository and upgrade to proguard 7.1.0-be…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
 		<cctimestamp>NO_TIMESTAMP</cctimestamp>
 		<scm.revision>NO_SCM_REVISION</scm.revision>
 
-		<version.proguard>7.0.0</version.proguard>
+		<version.proguard>7.1.0-beta3</version.proguard>
 	</properties>
 
 
 	<groupId>com.github.wvengen</groupId>
 	<artifactId>proguard-maven-plugin</artifactId>
 	<name>proguard-maven-plugin</name>
-	<version>2.3.1</version>
+	<version>2.3.2-beta</version>
 	<packaging>maven-plugin</packaging>
 
 	<description>Maven 3 Plugin for ProGuard</description>
@@ -74,17 +74,6 @@
 			<email>chuckame@gmail.com</email>
 		</contributor>
 	</contributors>
-
-	<repositories>
-		<repository>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>bintray-guardsquare-proguard</id>
-			<name>bintray</name>
-			<url>https://dl.bintray.com/guardsquare/proguard</url>
-		</repository>
-	</repositories>
 	
 	<dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<groupId>com.github.wvengen</groupId>
 	<artifactId>proguard-maven-plugin</artifactId>
 	<name>proguard-maven-plugin</name>
-	<version>2.3.2-beta</version>
+	<version>2.3.2-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<description>Maven 3 Plugin for ProGuard</description>


### PR DESCRIPTION
Remove phased-out bintray repository and upgrade to proguard 7.1.0-beta3 as it is the only one available at the moment on maven central.
I bumped the bug fix version and suffixed it with -beta as the proguard version is beta.
This is a temporary fix for issue #133 