### PR TITLE
Issue #130: Documentation site broken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.1</version>
 			</plugin>
 
 			<plugin>
@@ -168,10 +168,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.9.1</version>
 				<configuration>
 					<outputEncoding>UTF-8</outputEncoding>
 				</configuration>
+				<dependencies>
+							<dependency>
+								<groupId>org.apache.bcel</groupId>
+								<artifactId>bcel</artifactId>
+								<version>6.5.0</version>
+							</dependency>
+				</dependencies>
 			</plugin>
 
 			<plugin>
@@ -198,20 +205,20 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.6.1</version>
 			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.2</version>
 				<reportSets>
 					<reportSet>
 						<reports>
 							<report>dependencies</report>
 							<report>dependency-convergence</report>
 							<report>plugin-management</report>
-							<report>license</report>
+							<report>licenses</report>
 							<report>scm</report>
 							<report>summary</report>
 						</reports>


### PR DESCRIPTION
Fixes #130 
Fix site generation by updating dependencies.
Also license -> licenses is rerequired.