### PR TITLE
Use Mojo annotations instead of Javadoc tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,13 @@
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.9.11</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.15.1</version>
+			<!-- Only needed at build time -->
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -280,7 +286,7 @@
 						<configuration>
 							<projectsDirectory>${project.basedir}/src/it</projectsDirectory>
 							<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-							<localRepositoryPath>${projects.build.directory}/local-repo</localRepositoryPath>
+							<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
 							<!-- the .groovy extension (or .bsh, if you're using BeanShell) is implied -->
 							<postBuildHookScript>verify</postBuildHookScript>
 							<goals>


### PR DESCRIPTION
Resolves #399

I compared the resulting JAR files afterwards; there are some small differences:
- `plugin.xml` & `plugin-help.xml`:
   - `<description>` tags of parameters contain the value of Javadoc tags as plaintext instead of the Javadoc tag, e.g. `Determines if {@link #attach} also ...` became `Determines if attach also ...`.
     Not sure if that is intended but maybe this is not a big problem (or not a problem at all). The documentation generated by `mvn site` seems to be unaffected.
  - For the code which was previously using `@parameter expression=...` I replaced it with `@Parameter(defaultValue = "${...}")`. I think this should give the same behavior, see also the [(old) Maven book](https://books.sonatype.com/mvnref-book/reference/writing-plugins-sect-mojo-params.html#writing-plugins-sect-param-values).
  This also applies to some usage of `@parameter property=...`; I think that previously had the desired effect, but to my understanding `property` is rather intended to define a custom system property which users can use, as it is the case with the existing `proguard.skip` for this plugin.
- `plugin-help.xml`:
   `<type>` seems to contain the type argument for parameterized types now, e.g. previously it contained just `java.util.List`, now it is `java.util.List<String>`.

I have made some basic test and it seems to work fine, but if you have a local test setup it would be great if you could give it a try as well.