### PR TITLE
Set provided scope for maven-plugin-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.9.12</version>
+			<scope>provided</scope>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
The maven runtime already bundles maven-plugin-api for plugins. The dependency was declared without an explicit scope, causing the following dependency resolution warning under Maven 3.9+:
```
[WARNING] Plugin [INTERNAL, EXTERNAL] validation issues were detected in following plugin(s)
[WARNING] 
[WARNING]  * com.github.wvengen:proguard-maven-plugin:2.7.1-SNAPSHOT
[WARNING]   Plugin EXTERNAL issue(s):
[WARNING]    * Plugin should declare Maven artifacts in `provided` scope. If the plugin already declares them in `provided` scope, update the maven-plugin-plugin to latest version. Artifacts found with wrong scope: [org.apache.maven:maven-plugin-api:3.9.12]
```